### PR TITLE
Constraint compatibility

### DIFF
--- a/include/KFitParticle.h
+++ b/include/KFitParticle.h
@@ -46,9 +46,34 @@ private:
     double fR; // Closest distance to beamline [mm]
     double fZ; // Point along beamline where track is closest to it [mm]
 
+    double fGenMomentum;
+    double fGenTheta;
+    double fGenPhi;
+    double fGenR;
+    double fGenZ;
+
+    double fVtxX = -999999999.9;
+    double fVtxY = -999999999.9;
+    double fVtxZ = -999999999.9;
+    double fGenVtxX = -999999999.9;
+    double fGenVtxY = -999999999.9;
+    double fGenVtxZ = -999999999.9;
+
+    double fSector; // HADES sector 0-5
+
+    double fRapidity = -9999999999.9;
+    double fPt = -9999999999.9;
+    double fPx = -9999999999.9; 
+    double fPy = -9999999999.9; 
+    double fPz = -9999999999.9;  
+
     double fBeta = -9999999999.9;
     double fChi2 = -9999999999.9;
     double fTOF = -9999999999.9;
+
+    int fPID = -99999;
+    int fParentPID = -99999;
+    int fGrandParentPID = -99999;   
 
     int fCharge = 0;
 
@@ -108,12 +133,38 @@ public:
     void setPid(int val) { fPid = val; } // Sets the PID of the particle (user defined)
     void setTrackId(int val) { fTrackId = val; } // Sets the track id
     void setTOF(int val) { fTOF = val; } // Sets the tof
+    void setRapidity(int val) { fRapidity = val; } // Sets the rapidity
+    void setPt(double val) { fPt = val; } // Sets the transverse momentum [MeV/c]
+    void setPx(double val) { fPx = val; } // Sets the x momentum [MeV/c]
+    void setPy(double val) { fPy = val; } // Sets the y momentum [MeV/c]
+    void setPz(double val) { fPz = val; } // Sets the z momentum [MeV/c]
+    void setVertexX(double val) { fVtxX = val; } // Sets the x-vertex [mm]
+    void setVertexY(double val) { fVtxY = val; } // Sets the y-vertex [mm]
+    void setVertexZ(double val) { fVtxZ = val; } // Sets the z-vertex [mm]
+    void setGenVertexX(double val) { fGenVtxX = val; } // Sets the generated x-vertex [mm]
+    void setGenVertexY(double val) { fGenVtxY = val; } // Sets the generated y-vertex [mm]
+    void setGenVertexZ(double val) { fGenVtxZ = val; } // Sets the generated z-vertex [mm]
+
+    // MC Truth Matching Information
+    void setPID(int val) { fPID = val; }
+    void setParentPID(int val) { fParentPID = val; }
+    void setGrandParentPID(int val) {fGrandParentPID = val; }
+
+    void setGenMomentum(double val) { fGenMomentum = val; } // Sets the momentum [MeV/c]
+    void setGenThetaDeg(double val) { fGenTheta = val; } // Sets the polar angle [deg]
+    void setGenPhiDeg(double val) { fGenPhi = val; } // Sets the azimuthal angle [deg]
+    void setGenR(double val) { fGenR = val; } // Sets R [mm]
+    void setGenZ(double val) { fGenZ = val; } // Sets Z [mm]
+
+    void setSector(int val) { fSector = val; } // Sets the sector
 
     double getMomentum() const { return fMomentum; } // Returns the momentum [MeV/c]
     double getThetaRad() const { return fTheta; } // Returns the polar angle [radians]
     double getPhiRad() const { return fPhi; } // Returns the azimuthal angle [radians]
     double getThetaDeg() const { return fTheta*TMath::RadToDeg(); } // Returns the polar angle [deg]
     double getPhiDeg() const { return fPhi*TMath::RadToDeg(); } // Returns the azimuthal angle [deg]
+    double getGenThetaDeg() const { return fGenTheta; } // Returns the generated polar angle [deg]
+    double getGenPhiDeg() const { return fGenPhi; } // Returns the generated azimuthal angle [deg]
     double getR() const { return fR; } // Returns R [mm]
     double getZ() const { return fZ; } // Returns Z [mm]
     double getCharge() const { return fCharge; } // Returns  Charge
@@ -123,6 +174,30 @@ public:
     int getPid() const { return fPid; } // Returns the PID of the particle (user defined)
     int getTrackId() const { return fTrackId; } // Returns the track id
     int getTOF() const { return fTOF; } // Returns the TOF
+    double getPt() const { return fPt; } // Returns the transverse momentum [MeV/c]
+    double getPx() const { return fPx; } // Returns the x momentum [MeV/c]
+    double getPy() const { return fPy; } // Returns the y momentum [MeV/c]
+    double getPz() const { return fPz; } // Returns the z momentum [MeV/c]
+    double getVertexX() const { return fVtxX; } // Returns the x-vertex [mm]
+    double getVertexY() const { return fVtxY; } // Returns the y-vertex [mm] 
+    double getVertexZ() const { return fVtxZ; } // Returns the z-vertex [mm]
+    double getGenVertexX() const { return fGenVtxX; } // Returns the generated x-vertex [mm]
+    double getGenVertexY() const { return fGenVtxY; } // Returns the generated y-vertex [mm] 
+    double getGenVertexZ() const { return fGenVtxZ; } // Returns the generated z-vertex [mm]
+    double getRapidity() const { return fRapidity; } // Returns the rapidity
+
+    // MC Truth Matching Information
+    int getPID() const { return fPID; }
+    int getParentPID() const { return fParentPID; }
+    int getGrandParentPID() const { return fGrandParentPID; }
+
+    double getGenMomentum() const { return fGenMomentum; }
+    double getGenTheta() const { return fGenTheta; }
+    double getGenPhi() const { return fGenPhi; }
+    double getGenR() const { return fGenR; }
+    double getGenZ() const { return fGenZ; }
+
+    int getSector() const { return fSector; } // Returns the sector
 };
 
 #endif /* KFITPARTICLE_H */

--- a/include/KinFitter.h
+++ b/include/KinFitter.h
@@ -93,6 +93,7 @@ private:
     std::vector<double> fM; // Vector of particle masses
     TLorentzVector fInit;   // 4-vector used for constraint
     double fMass = 99999.9; // Mass used for constraint
+    double fMassMissingParticle = 99999.9; // Mass used for missing particle constraint
 
     // Constraints, true if constraint is set, only one at a time
     bool fMassConstraint = false;

--- a/include/KinFitter.h
+++ b/include/KinFitter.h
@@ -87,6 +87,7 @@ private:
     std::vector<KFitParticle> fCands; // Vector of input candidates
     KFitParticle fMother;             // Decaying particle
     TLorentzVector fMissDaughter;     // Missing decay product
+    std::vector <double > fMassVec;   // Vector of masses that is used if several mass fits are used
 
     // Data members for constraints
     int fNdf = 0;           // Number of degrees of freedom
@@ -107,9 +108,10 @@ private:
     int fNumIterations = 20; // Maximum number of iterations
 
     // Convergence criteria: difference in chi2, constraint equation d, difference in track parameters between iterations
+    // If default parameters are used only the chi2 will be used for convergence
     double fConvergenceCriterionChi2 = 1e-4;
-    double fConvergenceCriterionD = 1e-4;
-    double fConvergenceCriterionAlpha = 1e-4;
+    double fConvergenceCriterionD = 1e6;
+    double fConvergenceCriterionAlpha = 1e6;
 
     std::vector<int> fFlexiParticlesInFit;
     std::vector<std::vector<int >> fMassFitPair;
@@ -175,7 +177,15 @@ public:
      * @param val2 - Norm of all constraint equations
      * @param val2 - Difference in norm of track parameter vector of consecutive iterations
      */
-    void setConvergenceCriteria(double val1, double val2, double val3);
+    void setConvergenceCriteria(double val1, double val2, double val3){
+
+        fConvergenceCriterionChi2 = val1;
+        fConvergenceCriterionD = val2;
+        fConvergenceCriterionAlpha = val3;
+
+    }
+
+    void setConvergenceCriterionChi2(double val) { fConvergenceCriterionChi2 = val; }
 
     /** @brief Chi2 of the fit is returned
      */

--- a/include/KinFitter.h
+++ b/include/KinFitter.h
@@ -93,8 +93,8 @@ private:
     std::vector<double> fM; // Vector of particle masses
     TLorentzVector fInit;   // 4-vector used for constraint
     double fMass = 99999.9; // Mass used for constraint
-    double fMassMissingParticle = 99999.9; // Mass used for missing particle constraint
-
+    double fMassMissingParticle = 99999.9; // Mass used for constraint
+    
     // Constraints, true if constraint is set, only one at a time
     bool fMassConstraint = false;
     bool fMissingMassConstraint = false;
@@ -111,9 +111,13 @@ private:
     double fConvergenceCriterionD = 1e-4;
     double fConvergenceCriterionAlpha = 1e-4;
 
+    std::vector<int> fFlexiParticlesInFit;
+    std::vector<std::vector<int >> fMassFitPair;
+
     int fVerbose = 0;
 
-    double fNExclusive = -1;
+    int fNExclusive = -1;
+    int fNumMassFits = 0;
 
     TMatrixD calcMissingMom(const TMatrixD &m_iter);
 
@@ -157,7 +161,10 @@ public:
     void addMissingMassConstraint(TLorentzVector lv, double mass);     // Constrains all final state particles to the initial system, lv, and a missing mass , m
     void addMassVtxConstraint(double mass);                            // Constrains all particles to a common vertex and a mass, m, of a decaying particle
 
-    void setNumberOfExclusiveCandidates(double number) { fNExclusive = number; }
+    void setNumberOfExclusiveCandidates(int number) { fNExclusive = number; }
+    void setUseCandInFit(int number){ 
+        fFlexiParticlesInFit.push_back(number);
+     };
 
     /** @brief Set maximum number of iterations, default = 20
      */

--- a/source/KFitDecayBuilder.cxx
+++ b/source/KFitDecayBuilder.cxx
@@ -17,8 +17,8 @@
 #include "KFitDecayBuilder.h"
 
 KFitDecayBuilder::KFitDecayBuilder(TString task, std::vector<int> pids, TLorentzVector lv, double mass) : fTask(task),
-                                                                                                            fPids(pids),
-                                                                                                            fVerbose(0)
+                                                                                                          fPids(pids),
+                                                                                                          fVerbose(0)
 
 {
     if (fVerbose > 0)
@@ -28,7 +28,6 @@ KFitDecayBuilder::KFitDecayBuilder(TString task, std::vector<int> pids, TLorentz
 
     setIniSys(lv);
     setMass(mass);
-
 }
 
 void KFitDecayBuilder::countCombis()
@@ -40,13 +39,13 @@ void KFitDecayBuilder::countCombis()
     fCombiCounter = 0;
     // Determine the number of combinations of the input particles
     fTotalCombis = 1;
-    if(particleCounter.size()>0) particleCounter.clear();
+    if (particleCounter.size() > 0)
+        particleCounter.clear();
     for (size_t i = 0; i < fPids.size(); i++)
     {
         fTotalCombis *= fCands[i].size();
         particleCounter.push_back(0);
     }
-
 }
 
 void KFitDecayBuilder::buildDecay()
@@ -58,18 +57,18 @@ void KFitDecayBuilder::buildDecay()
     if (fVerbose > 1)
     {
         std::cout << "Combi counter: " << fCombiCounter << " total Combos: " << fTotalCombis << std::endl;
-        std::cout<< "Task is " << fTask <<std::endl;
+        std::cout << "Task is " << fTask << std::endl;
     }
 
     // For selection of best event according to probability
     fBestProb = 0;
     fBestChi2 = 1e6;
 
-    while (fCombiCounter < (fTotalCombis ))
+    while (fCombiCounter < (fTotalCombis))
     {
         // Take one combination of particles
         fillFitCands();
-        
+
         // Check if correct number of particles
         if (fFitCands.size() != fPids.size())
         {
@@ -91,13 +90,9 @@ void KFitDecayBuilder::buildDecay()
         if (fVerbose > 1)
         {
             std::cout << "Combi counter: " << fCombiCounter << " total Combos: " << fTotalCombis << std::endl;
-            std::cout << "fit finished" <<std::endl;
+            std::cout << "fit finished" << std::endl;
         }
-        
-        
-        
     }
-    
 }
 
 Bool_t KFitDecayBuilder::doFit()
@@ -107,12 +102,18 @@ Bool_t KFitDecayBuilder::doFit()
         std::cout << "--------------- KFitDecayBuilder::doFit() -----------------" << std::endl;
     }
     KinFitter Fitter(fFitCands);
-    if (fTask == "4C") Fitter.add4Constraint(fIniSys);
-    else if (fTask == "Vertex") Fitter.addVertexConstraint();
-    else if (fTask == "MassVtx") Fitter.addMassVtxConstraint(fMass);
-    else if (fTask == "MM" || fTask == "MissingMass" ) Fitter.addMissingMassConstraint(fIniSys, fMass);
-    else if (fTask == "Mom" || fTask == "MissingParticle") Fitter.addMissingParticleConstraint(fIniSys, fMass);
-    else if (fTask == "Mass"){
+    if (fTask == "4C")
+        Fitter.add4Constraint(fIniSys);
+    else if (fTask == "Vertex")
+        Fitter.addVertexConstraint();
+    else if (fTask == "MassVtx")
+        Fitter.addMassVtxConstraint(fMass);
+    else if (fTask == "MM" || fTask == "MissingMass")
+        Fitter.addMissingMassConstraint(fIniSys, fMass);
+    else if (fTask == "Mom" || fTask == "MissingParticle")
+        Fitter.addMissingParticleConstraint(fIniSys, fMass);
+    else if (fTask == "Mass")
+    {
         Fitter.addMassConstraint(fMass);
         /*
         cout << "constraint added, Mass = " << fMass << endl;
@@ -120,12 +121,12 @@ Bool_t KFitDecayBuilder::doFit()
         cout << "pion momentum = " << fFitCands[1].getMomentum() << endl;
         TMatrixD cov_p = fFitCands[0].getCovariance();
         TMatrixD cov_pi = fFitCands[1].getCovariance();
-        /*
         cout << "proton momentum error = " << cov_p(0,0) << endl;
         cout << "pion momentum error = " << cov_pi(0,0) << endl;
-*/
-    } 
-    else cout << "Task not available" << endl;
+        */
+    }
+    else
+        cout << "Task not available" << endl;
 
     if (Fitter.fit())
     {
@@ -137,7 +138,8 @@ Bool_t KFitDecayBuilder::doFit()
         {
             fBestProb = Fitter.getProb();
             fBestChi2 = Fitter.getChi2();
-            if(fOutputCands.size() != 0) fOutputCands.clear();
+            if (fOutputCands.size() != 0)
+                fOutputCands.clear();
             Fitter.getDaughters(fOutputCands);
         }
         return kTRUE;
@@ -159,9 +161,10 @@ void KFitDecayBuilder::fillFitCands()
         std::cout << "--------------- KFitDecayBuilder::fillFitCands() -----------------" << std::endl;
     }
 
-    if(fFitCands.size()>0) fFitCands.clear();
+    if (fFitCands.size() > 0)
+        fFitCands.clear();
     doubleParticle = false;
-    
+
     for (size_t i = 0; i < fPids.size(); i++)
     {
         checkDoubleParticle(i);
@@ -174,7 +177,7 @@ void KFitDecayBuilder::fillFitCands()
     int a = fPids.size() - 1;
     if (fVerbose > 1)
         std::cout << "particle counter " << a << " is " << particleCounter[a] << " now" << std::endl;
-    while (particleCounter[a] == (fCands[a].size() - 1))
+    while (particleCounter[a] == (((int)fCands[a].size()) - 1))
     {
         particleCounter[a] = 0;
         if (fVerbose > 1)
@@ -182,9 +185,9 @@ void KFitDecayBuilder::fillFitCands()
         a--;
         if (a < 0)
         {
-            if (!(fCombiCounter == fTotalCombis-1))
-            if (fVerbose > 1)
-                std::cout << "counted wrong: " << fCombiCounter << " != " << fTotalCombis << std::endl;
+            if (!(fCombiCounter == fTotalCombis - 1))
+                if (fVerbose > 1)
+                    std::cout << "counted wrong: " << fCombiCounter << " != " << fTotalCombis << std::endl;
             break;
 
             a = 1e6;
@@ -194,7 +197,6 @@ void KFitDecayBuilder::fillFitCands()
     if (fVerbose > 1)
         std::cout << "particle counter " << a << " is " << particleCounter[a] << " now" << std::endl;
     fCombiCounter++;
-    
 
     if (doubleParticle && (fCombiCounter < fTotalCombis))
         fillFitCands(); // If some particle has been filled more than once into fFitCands, repeat the procedure with the next combination

--- a/source/KinFitter.cxx
+++ b/source/KinFitter.cxx
@@ -233,7 +233,7 @@ void KinFitter::addMissingParticleConstraint(TLorentzVector lv, double mass)
     }
 
     fInit = lv;
-    fMass = mass;
+    fMassMissingParticle = mass;
 
     x.ResizeTo(3, 1);
     Vx.ResizeTo(3, 3);
@@ -242,7 +242,7 @@ void KinFitter::addMissingParticleConstraint(TLorentzVector lv, double mass)
 
     if (!fMissingParticleConstraint)
     {
-        fM.push_back(fMass);
+        fM.push_back(fMassMissingParticle);
         fNdf += 1;
     }
 
@@ -497,8 +497,8 @@ TMatrixD KinFitter::f_eval(const TMatrixD &m_iter, const TMatrixD &xi_iter)
 
     if (fVerbose > 2)
     {
-        std::cout<<"residuals - "<<std::flush;
-        d.Print();
+        //std::cout<<"residuals - "<<std::flush;
+        //d.Print();
     }
 
     return d;
@@ -1116,6 +1116,16 @@ TMatrixD KinFitter::Fxi_eval(const TMatrixD &m_iter, const TMatrixD &xi_iter)
         std::cout << "--------------- KinFitter::Fxi_eval() -----------------" << std::endl;
     }
 
+    if (fVerbose > 4)
+    {
+        //m_iter.Print();
+
+        //xi_iter.Print();
+    }
+
+    //std::cout << "CovDim: " << cov_dim << std::endl;
+    //std::cout << "fN: " << fN << std::endl;
+
     TMatrixD H;
 
     if (f3Constraint)
@@ -1132,6 +1142,8 @@ TMatrixD KinFitter::Fxi_eval(const TMatrixD &m_iter, const TMatrixD &xi_iter)
 
     if (fMissingParticleConstraint)
     {
+        //std::cout << "xi_iter: " << xi_iter(0, 0) << " " << xi_iter(1, 0) << " " << xi_iter(2, 0) << std::endl;
+
         H.ResizeTo(4, 3);
         H.Zero();
 
@@ -1142,7 +1154,97 @@ TMatrixD KinFitter::Fxi_eval(const TMatrixD &m_iter, const TMatrixD &xi_iter)
         H(3, 0) = xi_iter(0, 0) / sqrt(pow(xi_iter(0, 0), 2) + std::pow(xi_iter(1, 0), 2) + std::pow(xi_iter(2, 0), 2) + std::pow(fM[fN], 2));
         H(3, 1) = xi_iter(1, 0) / sqrt(pow(xi_iter(0, 0), 2) + std::pow(xi_iter(1, 0), 2) + std::pow(xi_iter(2, 0), 2) + std::pow(fM[fN], 2));
         H(3, 2) = xi_iter(2, 0) / sqrt(pow(xi_iter(0, 0), 2) + std::pow(xi_iter(1, 0), 2) + std::pow(xi_iter(2, 0), 2) + std::pow(fM[fN], 2));
+        
+        
     }
+    if (fMissingParticleConstraint&&fMassConstraint)
+    {
+        //std::cout << "xi_iter: " << xi_iter(0, 0) << " " << xi_iter(1, 0) << " " << xi_iter(2, 0) << std::endl;
+
+        H.ResizeTo(5, 3);
+        H.Zero();
+
+        H(0, 0) = 1;
+        H(1, 1) = 1;
+        H(2, 2) = 1;
+
+        H(3, 0) = xi_iter(0, 0) / sqrt(pow(xi_iter(0, 0), 2) + std::pow(xi_iter(1, 0), 2) + std::pow(xi_iter(2, 0), 2) + std::pow(fMassMissingParticle, 2));
+        H(3, 1) = xi_iter(1, 0) / sqrt(pow(xi_iter(0, 0), 2) + std::pow(xi_iter(1, 0), 2) + std::pow(xi_iter(2, 0), 2) + std::pow(fMassMissingParticle, 2));
+        H(3, 2) = xi_iter(2, 0) / sqrt(pow(xi_iter(0, 0), 2) + std::pow(xi_iter(1, 0), 2) + std::pow(xi_iter(2, 0), 2) + std::pow(fMassMissingParticle, 2));
+        
+        
+    }
+    // if (fMassConstraint && fMissingParticleConstraint)
+    // {
+
+    //     double Px = 0., Py = 0., Pz = 0., E = 0.;
+
+    //     if (fNExclusive != -1 && fNExclusive <= fN)
+    //     {
+    //         int cof = H.GetNrows();
+    //         H.ResizeTo(cof + 1, fyDim);
+    //         H(0, 0) = 1;
+    //         H(1, 1) = 1;
+    //         H(2, 2) = 1;
+
+    //         H(3, 0) = xi_iter(0, 0) / sqrt(pow(xi_iter(0, 0), 2) + std::pow(xi_iter(1, 0), 2) + std::pow(xi_iter(2, 0), 2) + std::pow(fM[fN], 2));
+    //         H(3, 1) = xi_iter(1, 0) / sqrt(pow(xi_iter(0, 0), 2) + std::pow(xi_iter(1, 0), 2) + std::pow(xi_iter(2, 0), 2) + std::pow(fM[fN], 2));
+    //         H(3, 2) = xi_iter(2, 0) / sqrt(pow(xi_iter(0, 0), 2) + std::pow(xi_iter(1, 0), 2) + std::pow(xi_iter(2, 0), 2) + std::pow(fM[fN], 2));
+            
+    //         // for (int k = 0; k < fyDim; k++)
+    //         // {
+    //         //     H(cof, k) = 0.;
+    //         // }
+    //         // // H.Zero();
+    //         // for (int q = 0; q < fNExclusive; q++)
+    //         // {
+    //         //     E += std::sqrt((1. / m_iter(0 + q * cov_dim, 0)) *
+    //         //                        (1. / m_iter(0 + q * cov_dim, 0)) +
+    //         //                    fM[q] * fM[q]);
+    //         //     Px += (1. / m_iter(0 + q * cov_dim, 0)) *
+    //         //           std::sin(m_iter(1 + q * cov_dim, 0)) *
+    //         //           std::cos(m_iter(2 + q * cov_dim, 0));
+    //         //     Py += (1. / m_iter(0 + q * cov_dim, 0)) *
+    //         //           std::sin(m_iter(1 + q * cov_dim, 0)) *
+    //         //           std::sin(m_iter(2 + q * cov_dim, 0));
+    //         //     Pz += (1. / m_iter(0 + q * cov_dim, 0)) *
+    //         //           std::cos(m_iter(1 + q * cov_dim, 0));
+    //         // }
+
+    //         // for (int q = 0; q < fNExclusive; q++)
+    //         // {
+    //         //     double Pi = 1. / m_iter(0 + q * cov_dim, 0);
+    //         //     double Ei = std::sqrt(Pi * Pi + fM[q] * fM[q]);
+
+    //         //     H(cof, 0 + q * cov_dim) =
+    //         //         -2 * E * (std::pow(Pi, 3) / Ei) +
+    //         //         2 * std::pow(Pi, 2) * std::sin(m_iter(1 + q * cov_dim, 0)) *
+    //         //             std::cos(m_iter(2 + q * cov_dim, 0)) * Px +
+    //         //         2 * std::pow(Pi, 2) * std::sin(m_iter(1 + q * cov_dim, 0)) *
+    //         //             std::sin(m_iter(2 + q * cov_dim, 0)) * Py +
+    //         //         2 * std::pow(Pi, 2) * std::cos(m_iter(1 + q * cov_dim, 0)) * Pz;
+
+    //         //     H(cof, 1 + q * cov_dim) =
+    //         //         -2 * Pi * std::cos(m_iter(1 + q * cov_dim, 0)) *
+    //         //             std::cos(m_iter(2 + q * cov_dim, 0)) * Px -
+    //         //         2 * Pi * std::cos(m_iter(1 + q * cov_dim, 0)) *
+    //         //             std::sin(m_iter(2 + q * cov_dim, 0)) * Py +
+    //         //         2 * Pi * std::sin(m_iter(1 + q * cov_dim, 0)) * Pz;
+
+    //         //     H(cof, 2 + q * cov_dim) =
+    //         //         2 * Pi * std::sin(m_iter(1 + q * cov_dim, 0)) *
+    //         //             std::sin(m_iter(2 + q * cov_dim, 0)) * Px -
+    //         //         2 * Pi * std::sin(m_iter(1 + q * cov_dim, 0)) *
+    //         //             std::cos(m_iter(2 + q * cov_dim, 0)) * Py;
+
+    //         //     H(cof, 3 + q * cov_dim) = 0.;
+    //         //     H(cof, 4 + q * 4) = 0.;
+    //         // }
+    //     }
+    // }
+
+    //std::cout << "H: " << std::endl;
+    //H.Print();
 
     return H;
 }
@@ -1174,8 +1276,8 @@ Bool_t KinFitter::fit()
     // Calculating the inverse of the original covariance matrix that is not changed in the iterations
     if (fVerbose > 2)
     {
-        std::cout<<"Original Covariance - "<<std::flush;
-        V.Print();
+        //std::cout<<"Original Covariance - "<<std::flush;
+        //V.Print();
     }
     TMatrixD V0_inv(V);
     V0_inv.Invert(&determinant);
@@ -1183,8 +1285,8 @@ Bool_t KinFitter::fit()
     if(determinant==0.) return kFALSE; // protect against failed matrix inversion
     if (fVerbose > 2)
     {
-        std::cout<<"Original Covariance inverted - "<<std::flush;
-        V0_inv.Print();
+        //std::cout<<"Original Covariance inverted - "<<std::flush;
+        //V0_inv.Print();
     }
 
     if (f4Constraint == false && f3Constraint == false && fVtxConstraint == false && fMissingParticleConstraint == false &&
@@ -1208,13 +1310,13 @@ Bool_t KinFitter::fit()
 
     if (fVerbose > 1)
     {
-        cout << " Calculate Feta" << endl;
+        //cout << " Calculate Feta" << endl;
     }
     TMatrixD D = Feta_eval(alpha, xi);
     TMatrixD DT(D.GetNcols(), D.GetNrows());
     if (fVerbose > 1)
     {
-        cout << " Calculate f" << endl;
+        //cout << " Calculate f" << endl;
     }
     TMatrixD d = f_eval(alpha, xi);
     TMatrixD D_xi(d.GetNrows(), 1), DT_xi(1, d.GetNrows());
@@ -1223,13 +1325,32 @@ Bool_t KinFitter::fit()
     DT_xi.ResizeTo(d.GetNrows() - fNdf, d.GetNrows()); // check dimension if other fitters are added
     D_xi.Zero();
     DT_xi.Zero();
+
+    //if (fVerbose > -7)
+    //{
+        //std::cout<<" D_xi after initialization"<<std::flush;
+        //D_xi.Print();
+
+    //}
+
     if (f3Constraint || fMissingParticleConstraint)
     {
         if (fVerbose > 1)
         {
-            cout << " Calculate Fxi" << endl;
+            //cout << " Calculate Fxi" << endl;
         }
-        D_xi = Fxi_eval(alpha, xi);
+        D_xi = Fxi_eval(alpha, xi); 
+        
+        if (fVerbose > 1)
+        {
+            //cout << "alpha" << endl;
+            //alpha.Print();
+            //cout << "xi" << endl;
+            //xi.Print();
+            std::cout << " ------------------------ After Fxi_eval-------------------------------------------" << std::endl;
+            cout << " D_xi" << endl;
+            D_xi.Print();
+        }
     }
     TMatrixD VD(D.GetNrows(), D.GetNrows());
     VD.Zero();
@@ -1238,6 +1359,11 @@ Bool_t KinFitter::fit()
 
     for (int q = 0; q < fNumIterations; q++)
     {
+        if (fVerbose > -1)
+        {
+            std::cout << "Number of iterations: " << q << std::endl;
+        }
+
         TMatrixD delta_alpha = alpha0 - alpha;
         // Calculate r
         if (fVerbose > 1)
@@ -1247,16 +1373,16 @@ Bool_t KinFitter::fit()
         TMatrixD r = d + D * delta_alpha;
         if (fVerbose > 2)
         {
-            std::cout<<"delta_alpha - "<<std::flush;
-            delta_alpha.Print();
-            std::cout<<"r = f_eta + F_eta*delta_alpha- "<<std::flush;
-            r.Print();
+            //std::cout<<"delta_alpha - "<<std::flush;
+            //delta_alpha.Print();
+            //std::cout<<"r = f_eta + F_eta*delta_alpha- "<<std::flush;
+            //r.Print();
         }
         DT.Transpose(D);
         // Calculate S
         if (fVerbose > 1)
         {
-            cout << " Calculate S" << endl;
+            //cout << " Calculate S" << endl;
         }
         VD = D * V0 * DT;
         VD.Invert(&determinant);
@@ -1267,23 +1393,53 @@ Bool_t KinFitter::fit()
         }
         if (fVerbose > 2)
         {
-            std::cout<<"(D*V0*Dt)^-1 - "<<std::flush;
-            VD.Print();
+            //std::cout<<"(D*V0*Dt)^-1 - "<<std::flush;
+            //VD.Print();
         }
         if (f3Constraint || fMissingParticleConstraint)
         {
             DT_xi.Transpose(D_xi);
             if (fVerbose > 1)
             {
-                cout << " Calculate Sxi" << endl;
+                //cout << " Calculate Sxi" << endl;
             }
-            VDD = DT_xi * VD * D_xi;
-            VDD.Invert(&determinant);
+            VDD = DT_xi * VD * D_xi; ///-----------------------VDD ends up zero, D_xi is zero
+            
+            if (fVerbose > 1)
+            {                
+                std::cout << "DT_xi:" << std::endl;
+                DT_xi.Print();                
+                std::cout << "VD:" << std::endl;
+                VD.Print();
+                std::cout << "D_xi:" << std::endl;
+                D_xi.Print();
+                std::cout << "VDD:" << std::endl;
+                VDD.Print();
+            }
+            if (fVerbose > 1)
+            {
+                std::cout << " ------------------------ Before  VDD.Invert(&determinant);-------------------------------------------" << std::endl;
+            }
+            VDD.Invert(&determinant);            
+            
+            if (fVerbose > 1)
+            {
+                std::cout << " ------------------------ After  VDD.Invert(&determinant);-------------------------------------------" << std::endl;
+            }
             std::cerr<<std::flush;
             if(determinant==0.) {
                 if (q==0) return kFALSE; // protect against failed matrix inversion
                 else break; // we had a good iteration?
+            }            
+            if (fVerbose > 1)
+            {
+                std::cout << " ------------------------ After if Determinant zero-------------------------------------------" << std::endl;
             }
+        }
+
+        if (fVerbose > 1)
+        {
+            std::cout << " ------------------------ After f3Constraint || fMissingParticleConstraint -------------------------------------------" << std::endl;
         }
 
         // Calculate values for next iteration
@@ -1293,15 +1449,15 @@ Bool_t KinFitter::fit()
         {
             if (fVerbose > 1)
             {
-                cout << " Calculate neuxi" << endl;
+                //cout << " Calculate neuxi" << endl;
             }
             neu_xi = xi - VDD * DT_xi * VD * r;
         }
         TMatrixD delta_xi = neu_xi - xi;
         if (fVerbose > 2)
         {
-            std::cout<<"delta_xi - "<<std::flush;
-            delta_xi.Print();
+            //std::cout<<"delta_xi - "<<std::flush;
+            //delta_xi.Print();
         }
         if (fVerbose > 1)
         {
@@ -1312,20 +1468,26 @@ Bool_t KinFitter::fit()
         lambdaT.Transpose(lambda);
         if (fVerbose > 2)
         {
-            std::cout<<"Lambda - "<<std::flush;
-            lambda.Print();
+            //std::cout<<"Lambda - "<<std::flush;
+            //lambda.Print();
         }
+
+        if (fVerbose > 1)
+        {
+            std::cout << " ------------------------ After lambda transpose -------------------------------------------" << std::endl;
+        }
+
         TMatrixD neu_alpha(fyDim, 1);
         if (fVerbose > 1)
         {
-            cout << " Calculate neueta" << endl;
+            //cout << " Calculate neueta" << endl;
         }
         neu_alpha = alpha0 - V0 * DT * lambda;
         delta_alpha = alpha0 - neu_alpha;
         if (fVerbose > 2)
         {
-            std::cout<<"update delta_alpha - "<<std::flush;
-            delta_alpha.Print();
+            //std::cout<<"update delta_alpha - "<<std::flush;
+            //delta_alpha.Print();
         }
 
         // Calculate new chi2
@@ -1336,9 +1498,14 @@ Bool_t KinFitter::fit()
         two(0, 0) = 2;
         if (fVerbose > 1)
         {
-            cout << " Calculate chi2" << endl;
+            //cout << " Calculate chi2" << endl;
         }
         chisqrd = delta_alphaT * V0_inv * delta_alpha + two * lambdaT * f_eval(neu_alpha, neu_xi);
+        
+        if (fVerbose > 1)
+        {
+            std::cout << " ------------------------ After Chi2 Calc -------------------------------------------" << std::endl;
+        }
 
         // For testing the convergence
         fIteration = q;
@@ -1347,8 +1514,8 @@ Bool_t KinFitter::fit()
         TMatrixD delta_alpha_it = alpha - neu_alpha;
         if (fVerbose > 2)
         {
-            std::cout<<"delta_alpha iteration - "<<std::flush;
-            delta_alpha_it.Print();
+            //std::cout<<"delta_alpha iteration - "<<std::flush;
+            //delta_alpha_it.Print();
         }
 
         for (int i = 0; i < d.GetNrows(); i++)
@@ -1364,9 +1531,9 @@ Bool_t KinFitter::fit()
         alphaNorm = sqrt(alphaNorm);
         if (fVerbose > 2)
         {
-            cout << "Chi2: " << fabs(chi2 - chisqrd(0, 0)) << endl;
-            cout << "Delta apha norm: " << alphaNorm << endl;
-            cout << "Constraints norm: " << dNorm << endl;
+            //cout << "Chi2: " << fabs(chi2 - chisqrd(0, 0)) << endl;
+            //cout << "Delta apha norm: " << alphaNorm << endl;
+            //cout << "Constraints norm: " << dNorm << endl;
         }
         if (fabs(chi2 - chisqrd(0, 0)) < fConvergenceCriterionChi2 && dNorm < fConvergenceCriterionD && alphaNorm < fConvergenceCriterionAlpha)
         {
@@ -1380,9 +1547,9 @@ Bool_t KinFitter::fit()
 
         if (fVerbose > 0)
         {
-            std::cout << "Iteration: " << q << std::endl;
-            std::cout << "Printing d: " << std::endl;
-            d.Print();
+            //std::cout << "Iteration: " << q << std::endl;
+            //std::cout << "Printing d: " << std::endl;
+            //d.Print();
         }
 
         chi2 = chisqrd(0, 0);
@@ -1393,6 +1560,12 @@ Bool_t KinFitter::fit()
         if (f3Constraint || fMissingParticleConstraint)
             D_xi = Fxi_eval(alpha, xi);
         d = f_eval(alpha, xi);
+
+        if (fVerbose > -1)
+        {
+            std::cout << " ------------------------ END OF LOOP -------------------------------------------" << std::endl;
+        }
+
     }
 
     if (fVerbose > 0)
@@ -1422,7 +1595,7 @@ Bool_t KinFitter::fit()
         V = V0 - V0 * (DT * VD * D - (matrix * invertedMatrix * matrixT)) * V0;
         Vx = invertedMatrix;
     }
-    if (fVtxConstraint || f4Constraint || fMassConstraint || fMissingMassConstraint || fMassVtxConstraint)
+    if (fVtxConstraint || f4Constraint || (fMassConstraint&&(fMissingParticleConstraint==false)) || fMissingMassConstraint || fMassVtxConstraint)
         V = V0 - V0 * DT * VD * D * V0;
 
     // -----------------------------------------

--- a/source/KinFitter.cxx
+++ b/source/KinFitter.cxx
@@ -30,6 +30,7 @@ KinFitter::KinFitter(const std::vector<KFitParticle> &cands) : fCands(cands)
     // fN is the number of daughters e.g. (L->ppi-) n=2
     fN = fCands.size();
     fyDim = fN * cov_dim; // Dimension of full covariance matrix (number of measured variables x cov_dim)
+    fMassVec.clear();
 
     y.ResizeTo(fyDim, 1);
     x.ResizeTo(1, 1);
@@ -93,6 +94,7 @@ void KinFitter::addMassConstraint(double mass)
     fMassFitPair.push_back(fFlexiParticlesInFit);
     fFlexiParticlesInFit.clear();
     fMass = mass;
+    fMassVec.push_back(mass);
     //if (!fMassConstraint)
         fNdf += 1;
     fMassConstraint = true;
@@ -501,7 +503,7 @@ TMatrixD KinFitter::f_eval(const TMatrixD &m_iter, const TMatrixD &xi_iter)
                           std::cos(m_iter(1 + particle * cov_dim, 0));
                 }
                 d(cof, 0) = std::pow(E, 2) - std::pow(Px, 2) - std::pow(Py, 2) -
-                            std::pow(Pz, 2) - fMass * fMass;
+                            std::pow(Pz, 2) - fMassVec[numMassFits] * fMassVec[numMassFits];
             }
         }
         else
@@ -1115,7 +1117,7 @@ TMatrixD KinFitter::Feta_eval(const TMatrixD &m_iter, const TMatrixD &xi_iter)
                           std::cos(m_iter(1 + particle * cov_dim, 0));
                 }
 
-                for (int q = 0; q < fFlexiParticlesInFit.size(); q++)
+                for (int q = 0; q < (int) fFlexiParticlesInFit.size(); q++)
                 {
 
                     int particle = fFlexiParticlesInFit[q];
@@ -1798,13 +1800,6 @@ void KinFitter::updateMother()
     cov(4, 4) = V(3 + fN * cov_dim, 3 + fN * cov_dim);
     mother.setCovariance(cov);
     // ---------------------------------------------------------------------------
-}
-
-void KinFitter::setConvergenceCriteria(double val1, double val2, double val3)
-{
-    fConvergenceCriterionChi2 = val1;
-    fConvergenceCriterionD = val2;
-    fConvergenceCriterionAlpha = val3;
 }
 
 ClassImp(KinFitter)


### PR DESCRIPTION
Fixed the compatibility between the mass fit and missing particle fit. Also fixed so the mass fit can be used several times, e.g. for different particles in one fit. 